### PR TITLE
Remove direct coupling to Mainwindow from Parser, convert Actions to events

### DIFF
--- a/LostArkLogger/MainWindow.cs
+++ b/LostArkLogger/MainWindow.cs
@@ -24,7 +24,10 @@ namespace LostArkLogger
             overlay = new Overlay();
             overlay.sniffer = sniffer;
             overlay.Show();
-            sniffer = new Parser(this);
+            sniffer = new Parser();
+            sniffer.onPacketTotalCount += (int totalPacketCount) => {
+                this.loggedPacketCountLabel.Text = "Logged Packets : " + totalPacketCount;
+            };
             overlay.AddSniffer(sniffer);
         }
 
@@ -40,7 +43,7 @@ namespace LostArkLogger
 
         private void logEnabled_CheckedChanged(object sender, EventArgs e)
         {
-            //sniffer.log
+            this.sniffer.enableLogging = logEnabled.Checked;
         }
 
         private void clearButton_Click(object sender, EventArgs e)

--- a/LostArkLogger/Overlay.cs
+++ b/LostArkLogger/Overlay.cs
@@ -20,8 +20,8 @@ namespace LostArkLogger
         internal void AddSniffer(Parser s)
         {
             sniffer = s;
-            sniffer.addDamageEvent = AddDamageEvent;
-            sniffer.newZone = NewZone;
+            sniffer.onDamageEvent += AddDamageEvent;
+            sniffer.onNewZone += NewZone;
         }
         public void NewZone()
         {
@@ -136,6 +136,13 @@ namespace LostArkLogger
                 }
             }
             base.WndProc(ref m);
+        }
+
+        public new void Dispose()
+        {
+            sniffer.onDamageEvent -= AddDamageEvent;
+            sniffer.onNewZone -= NewZone;
+            base.Dispose();
         }
     }
 }

--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -18,12 +18,12 @@ namespace LostArkLogger
     internal class Parser : IDisposable
     {
         Machina.TCPNetworkMonitor tcp;
-        MainWindow main;
-        public Action newZone;
-        public Action<LogInfo> addDamageEvent;
-        public Parser(MainWindow m)
+        public event Action<LogInfo> onDamageEvent;
+        public event Action onNewZone;
+        public event Action<int> onPacketTotalCount;
+        public bool enableLogging = true;
+        public Parser()
         {
-            main = m;
             var tcp = new Machina.TCPNetworkMonitor();
             tcp.Config.WindowName = "LOST ARK (64-bit, DX11) v.2.2.3.1";
             tcp.Config.MonitorType = Machina.Infrastructure.NetworkMonitorType.RawSocket;
@@ -39,7 +39,7 @@ namespace LostArkLogger
             var packets = data.ToArray();
             var packetWithTimestamp = BitConverter.GetBytes(DateTime.UtcNow.ToBinary()).ToArray().Concat(data);
             loggedPacketCount++;
-            main.loggedPacketCountLabel.Text = "Logged Packets : " + loggedPacketCount;
+
             while (packets.Length > 0)
             {
                 if (fragmentedPacket.Length > 0)
@@ -104,7 +104,7 @@ namespace LostArkLogger
                 {
                     var pc = new PKTInitEnv(payload);
                     IdToName[pc.PlayerId] = "You";
-                    newZone?.Invoke();
+                    onNewZone?.Invoke();
                 }
                 /*if ((OpCodes)BitConverter.ToUInt16(converted.ToArray(), 2) == OpCodes.PKTRemoveObject)
                 {
@@ -129,7 +129,7 @@ namespace LostArkLogger
                             //var log = new LogInfo { Time = DateTime.Now, Source = sourceName, PC = sourceName.Contains("("), Destination = destinationName, SkillName = skillName, Crit = (dmgEvent.FlagsMaybe & 0x81) > 0, BackAttack = (dmgEvent.FlagsMaybe & 0x10) > 0, FrontAttack = (dmgEvent.FlagsMaybe & 0x20) > 0 };
                             var log = new LogInfo { Time = DateTime.Now, Source = sourceName, PC = true, Destination = destinationName, SkillName = skillName, Damage = dmgEvent.Damage, Crit = (dmgEvent.FlagsMaybe & 0x81) > 0, BackAttack = (dmgEvent.FlagsMaybe & 0x10) > 0, FrontAttack = (dmgEvent.FlagsMaybe & 0x20) > 0 };
                             AppendLog(log.ToString());
-                            addDamageEvent?.Invoke(log);
+                            onDamageEvent?.Invoke(log);
                         }
                     }
                 }
@@ -149,7 +149,7 @@ namespace LostArkLogger
         int loggedPacketCount = 0;
         void AppendLog(String s)
         {
-            if (main.logEnabled.Checked) File.AppendAllText(fileName, s + "\n");
+            if (enableLogging) File.AppendAllText(fileName, s + "\n");
         }
         void Device_OnPacketArrival(Machina.Infrastructure.TCPConnection connection, byte[] bytes)
         {
@@ -159,7 +159,7 @@ namespace LostArkLogger
             {
                 if (currentIpAddr == 0xdeadbeef || (bytes.Length > 4 && (OpCodes)BitConverter.ToUInt16(bytes, 2) == OpCodes.PKTAuthTokenResult && bytes[0] == 0x1e))
                 {
-                    newZone?.Invoke();
+                    onNewZone?.Invoke();
                     currentIpAddr = srcAddr;
                     fileName = "logs\\LostArk_" + DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss") + ".log";
                     loggedPacketCount = 0;


### PR DESCRIPTION
Removing direct UI coupling for Parser so it could in the future be used as headless