### PR TITLE
Use universal time in logs

### DIFF
--- a/LostArkLogger/Data/LogInfo.cs
+++ b/LostArkLogger/Data/LogInfo.cs
@@ -14,17 +14,8 @@ namespace LostArkLogger
         public Boolean FrontAttack { get; set; }
         public override string ToString()
         {
-            return Time.ToString("yy:MM:dd:HH:mm:ss.f") + "," +
+            return Time.ToUniversalTime() + "," +
                    Source + "," +
-                   Destination + "," +
-                   SkillName + "," +
-                   Damage + "," +
-                   (Crit ? "1" : "0") + "," +
-                   (BackAttack ? "1" : "0") + "," +
-                   (FrontAttack ? "1" : "0");
-            return Time.ToString("yy:MM:dd:HH:mm:ss.f") + "," +
-                   Source + "," +
-                   PC + "," +
                    Destination + "," +
                    SkillName + "," +
                    Damage + "," +


### PR DESCRIPTION
I'm not sure why there isn't a standardized timestamp format in the logs? The current one a pain to parse and several users already use different separators in timestamp for their log lines. So I'm proposing we move to UTC timestamps