### PR TITLE
chore: fallback detection for player id.

### DIFF
--- a/LostArkLogger/Packets/PKTInitLocal.cs
+++ b/LostArkLogger/Packets/PKTInitLocal.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace LostArkLogger.Packets
+{
+    public class PKTInitLocal
+    {
+        //00 00 03 00 55 00 54 00 43 00 AA EB BB 93 00 00 00 00 E6 57 86 5D 01 6B 00 00 01 00 00 00 01 25 19 24 0B 00 00 00 00 00 00 00 00
+        public UInt64 PlayerId;
+        public PKTInitLocal(Byte[] bytes)
+        {
+            PlayerId = BitConverter.ToUInt32(bytes, 1);
+        }
+    }
+}

--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -99,6 +99,13 @@ namespace LostArkLogger
                     Entities.Add(new Entity { EntityId = pc.PlayerId, Name = "You" });
                     onNewZone?.Invoke();
                 }
+                else if (opcode == OpCodes.PKTInitLocal)
+                {
+                    Entities.Clear();
+                    var pc = new PKTInitLocal(payload);
+                    Entities.Add(new Entity { EntityId = pc.PlayerId, Name = "You" });
+                    onNewZone?.Invoke();
+                }
                 /*if ((OpCodes)BitConverter.ToUInt16(converted.ToArray(), 2) == OpCodes.PKTRemoveObject)
                 {
                     var projectile = new PKTRemoveObject { Bytes = converted };


### PR DESCRIPTION
PKTInitLocal seems to have consistent location of the player id which is after the first byte. A good fallback if PlayerID is wrong in PKTInitEnv