### PR TITLE
Death counter

### DIFF
--- a/LostArkLogger/Data/Encounter.cs
+++ b/LostArkLogger/Data/Encounter.cs
@@ -9,9 +9,10 @@ namespace LostArkLogger
     {
         public DateTime Start = DateTime.Now;
         public DateTime End;
-        public UInt32 deaths = 0;
+        public UInt32 EDeaths = 0;
         public ConcurrentDictionary<UInt64, Entity> Entities = new ConcurrentDictionary<UInt64, Entity>();
         public ConcurrentBag<LogInfo> Infos = new ConcurrentBag<LogInfo>();
+        public ConcurrentBag<LogInfo> MaintainedInfo = new ConcurrentBag<LogInfo>();
         public String EncounterName
         {
             get
@@ -24,6 +25,13 @@ namespace LostArkLogger
             get
             {
                 return Infos.Where(i=>i.Counter).GroupBy(i => i.SourceEntity.VisibleName).Select(i => new KeyValuePair<String, UInt64>(i.Key, (UInt64)i.Sum(j => j.Counter ? 1 : 0))).ToDictionary(x => x.Key, x => x.Value);
+            }
+        }
+        public Dictionary<String, UInt64> Deaths
+        {
+            get
+            {
+                return MaintainedInfo.Where(i => i.Death).GroupBy(i => i.SourceEntity.VisibleName).Select(i => new KeyValuePair<String, UInt64>(i.Key, (UInt64)i.Sum(j => j.Death ? 1 : 0))).ToDictionary(x => x.Key, x => x.Value);
             }
         }
         public Dictionary<String, UInt64> Stagger

--- a/LostArkLogger/Data/Encounter.cs
+++ b/LostArkLogger/Data/Encounter.cs
@@ -9,6 +9,7 @@ namespace LostArkLogger
     {
         public DateTime Start = DateTime.Now;
         public DateTime End;
+        public UInt32 deaths = 0;
         public ConcurrentDictionary<UInt64, Entity> Entities = new ConcurrentDictionary<UInt64, Entity>();
         public ConcurrentBag<LogInfo> Infos = new ConcurrentBag<LogInfo>();
         public String EncounterName

--- a/LostArkLogger/Data/LogInfo.cs
+++ b/LostArkLogger/Data/LogInfo.cs
@@ -17,6 +17,7 @@ namespace LostArkLogger
         public Boolean BackAttack { get; set; }
         public Boolean FrontAttack { get; set; }
         public Boolean Counter { get; set; }
+        public Boolean Death { get; set; }
         public override string ToString()
         {
             return Time.ToString("yy:MM:dd:HH:mm:ss.f") + "," +

--- a/LostArkLogger/Overlay.cs
+++ b/LostArkLogger/Overlay.cs
@@ -18,6 +18,7 @@ namespace LostArkLogger
             Stagger,
             Heal,
             Shield,
+            Death,
             Max
         }
         enum Scope // need better state, suboverlay type/etc.
@@ -113,9 +114,11 @@ namespace LostArkLogger
                     level == Level.Stagger ? i.Stagger :
                     level == Level.Counterattacks ? (i.Counter ? 1u : 0) :
                     level == Level.Heal ? i.Heal :
-                    level == Level.Shield ? i.Shield : 0)), SubEntity);
-                if (level == Level.Damage) rows = encounter.GetDamages((i=>i.Damage), SubEntity);
+                    level == Level.Shield ? i.Shield : 
+                    level == Level.Death ? (i.Death ? 1u : 0) : 0)), SubEntity);
+                if (level == Level.Damage) rows = encounter.GetDamages((i => i.Damage), SubEntity);
                 else if (level == Level.Counterattacks) rows = encounter.Counterattacks.ToDictionary(x => x.Key, x => Tuple.Create(x.Value, 0u, 0u));
+                else if (level == Level.Death) rows = encounter.Deaths.ToDictionary(x => x.Key, x => Tuple.Create(x.Value,0u, 0u));
                 else if (level == Level.Stagger) rows = encounter.Stagger.ToDictionary(x => x.Key, x => Tuple.Create(x.Value, 0u, 0u));
                 var elapsed = ((encounter.End == default(DateTime) ? DateTime.Now : encounter.End) - encounter.Start).TotalSeconds;
                 var maxDamage = rows.Count == 0 ? 0 : rows.Max(b => b.Value.Item1);

--- a/LostArkLogger/Packets/PKTDeathNotify.cs
+++ b/LostArkLogger/Packets/PKTDeathNotify.cs
@@ -16,8 +16,8 @@ namespace LostArkLogger
             hasfield5 = reader.ReadByte();
             if (hasfield5 == 1)
                 field5 = reader.ReadByte();
-            field6 = reader.ReadUInt64();
-            field7 = reader.ReadUInt64();
+            source = reader.ReadUInt64();
+            target = reader.ReadUInt64();
             hasfield8 = reader.ReadByte();
             if (hasfield8 == 1)
                 field8 = reader.ReadByte();
@@ -30,8 +30,8 @@ namespace LostArkLogger
         public UInt64 field4;
         public Byte hasfield5;
         public Byte field5;
-        public UInt64 field6;
-        public UInt64 field7;
+        public UInt64 target;
+        public UInt64 source;
         public Byte hasfield8;
         public Byte field8;
     }

--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -323,6 +323,7 @@ namespace LostArkLogger
                     if (opcode == OpCodes.PKTRaidBossKillNotify || opcode == OpCodes.PKTTriggerBossBattleStatus)
                         currentEncounter.Entities = Encounters.Last().Entities; // preserve entities 
                     Encounters.Add(currentEncounter);
+                    
                 }
                 /*if ((OpCodes)BitConverter.ToUInt16(converted.ToArray(), 2) == OpCodes.PKTRemoveObject)
                 {
@@ -378,6 +379,28 @@ namespace LostArkLogger
                         Damage = 0, Counter = true
                     };
                     onCombatEvent?.Invoke(log);
+                }
+                else if (opcode == OpCodes.PKTDeathNotify) // todo: provide a UI to set death limit and add death counter to meter
+                {
+                    var Max_deaths = 2; 
+
+
+                    var Death = new PKTDeathNotify(new BitReader(payload));
+                    var Target = currentEncounter.Entities.GetOrAdd(Death.target);
+                    if ((currentEncounter.deaths < Max_deaths) & (Target.Type == Entity.EntityType.Player))
+                    {
+                        var log = new LogInfo
+                        {
+                            Time = DateTime.Now,
+                            SourceEntity = currentEncounter.Entities.GetOrAdd(Death.target),
+                            DestinationEntity = Target,
+                            SkillName = "Death",
+                            Damage = 0,
+                            Counter = false
+                        };
+                        currentEncounter.deaths++;
+                        onCombatEvent?.Invoke(log);
+                    }
                 }
                 else if (opcode == OpCodes.PKTNewNpcSummon)
                 {

--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -385,12 +385,10 @@ namespace LostArkLogger
                 }
                 else if (opcode == OpCodes.PKTDeathNotify) // todo: provide a UI to set death limit
                 {
-                    var Max_deaths = 2; 
-
 
                     var Death = new PKTDeathNotify(new BitReader(payload));
                     var Target = currentEncounter.Entities.GetOrAdd(Death.target);
-                    if ((currentEncounter.EDeaths < Max_deaths) & (Target.Type == Entity.EntityType.Player))
+                    if (Target.Type == Entity.EntityType.Player)
                     {
                         var log = new LogInfo
                         {
@@ -499,7 +497,9 @@ namespace LostArkLogger
         }
         private void Parser_onDamageEvent(LogInfo log)
         {
-            if (log.Death)
+            var Max_deaths = 2;
+
+            if (log.Death && currentEncounter.EDeaths <= Max_deaths)
             {
                 currentEncounter.MaintainedInfo.Add(log);
             }


### PR DESCRIPTION
Added death counter. currently Is hard coded to only count the first 2 deaths of every encounter. Death count is reset on raid end, but not raid wipe or boss death. (for example death count will not reset for every attempted valton pull, only a raid disband or completion)