### PR TITLE
Update Overlay.cs

### DIFF
--- a/LostArkLogger/GUI/Overlay.cs
+++ b/LostArkLogger/GUI/Overlay.cs
@@ -180,7 +180,8 @@ namespace LostArkLogger
                         }*/
                         var skillid = rowText.Substring(1);
                         skillid = skillid.Substring(0, skillid.IndexOf(")"));
-                        rowText = Skill.GetSkillName(uint.Parse(skillid));
+                        if (uint.TryParse(skillid, out uint parsedSkillID))
+                            rowText = Skill.GetSkillName(parsedSkillID);
                     }
                     var edge = e.Graphics.MeasureString(formattedDmg, font);
                     e.Graphics.DrawString(rowText, font, black, nameOffset + 5, (i + 1) * barHeight + heightBuffer);


### PR DESCRIPTION
change uint.parse to uint.tryparse to prevent exception for wrongly formatted string
For counterattacks, the substring skillid created from rowText is the wrong format. throws an exception trying to parse it