### PR TITLE
Patch UI/Packet Processing Lag in Fights with a lot of players

### DIFF
--- a/LostArkLogger/GUI/Overlay.cs
+++ b/LostArkLogger/GUI/Overlay.cs
@@ -94,7 +94,7 @@ namespace LostArkLogger
          "Soulfist", "Sharpshooter", "Artillerist", "dummyfill", "Bard", "Glavier", "Assassin", "Deathblade", "Shadowhunter", "Paladin", "Scouter", "Reaper", "FemaleGunner", "Gunslinger", "MaleMartialArtist", "Striker", "Sorceress" };
         public Pen arrowPen = new Pen(Color.FromArgb(255, 255, 255, 255), 4) { StartCap = System.Drawing.Drawing2D.LineCap.ArrowAnchor };
         IOrderedEnumerable<KeyValuePair<String, Tuple<UInt64, UInt32, UInt32, UInt64>>> orderedRows;
-
+        private readonly Bitmap ClassSymbols = Properties.Resources.class_symbol_0;
         protected void OnPaintStatusEffectTimes(PaintEventArgs e, float heightBuffer)
         {
             var rows = scope == Scope.Player ? encounter.GetStatusEffects(SubEntity) : encounter.GetStatusEffects();
@@ -111,7 +111,7 @@ namespace LostArkLogger
                 {
                     var className = rowData.Key[(rowData.Key.IndexOf("(") + 1)..];
                     className = className.Substring(0, className.IndexOf(")")).Split(' ')[1];
-                    e.Graphics.DrawImage(Properties.Resources.class_symbol_0, new Rectangle(2, (i + 1) * barHeight + 2, barHeight - 4, barHeight - 4), GetSpriteLocation(Array.IndexOf(ClassIconIndex, className)), GraphicsUnit.Pixel);
+                    e.Graphics.DrawImage(ClassSymbols, new Rectangle(2, (i + 1) * barHeight + 2, barHeight - 4, barHeight - 4), GetSpriteLocation(Array.IndexOf(ClassIconIndex, className)), GraphicsUnit.Pixel);
                     nameOffset += 2 + barHeight - 4;
                 }
                 var edge = e.Graphics.MeasureString(infoString, font);
@@ -224,7 +224,7 @@ namespace LostArkLogger
                     {
                         var className = rowText.Substring(rowText.IndexOf("(") + 1);
                         className = className.Substring(0, className.IndexOf(")")).Split(' ')[1];
-                        e.Graphics.DrawImage(Properties.Resources.class_symbol_0, new Rectangle(2, (i + 1) * barHeight + 2, barHeight - 4, barHeight - 4), GetSpriteLocation(Array.IndexOf(ClassIconIndex, className)), GraphicsUnit.Pixel);
+                        e.Graphics.DrawImage(ClassSymbols, new Rectangle(2, (i + 1) * barHeight + 2, barHeight - 4, barHeight - 4), GetSpriteLocation(Array.IndexOf(ClassIconIndex, className)), GraphicsUnit.Pixel);
                         nameOffset += 16;
                     }
                     if (scope == Scope.Player)


### PR DESCRIPTION
I investigated why the logger has performance problems during bigger fights world boss / chaos gate with a profiler.
The two two things most time was spend on where in order of time spent:

1. Getting the Bitmap with class icons from the Resource Manager (it spent more time there then on everything else together).
So I am now loading the class icon bitmap once and saving it in a local object.

2. Updating the packet count, more specifically setting the text on the UI element.
Additionally this call is currently done from outside the UI thread, which should not be done in the first place.
Changed the Packet count to use DataBinding which should be more performant and avoid accessing UI Controls from an invalid thread.

Also to note, there was a patch merged earlier that put File writes into a Task. If one wants the logger to be async it should be mandatory to guarantee that the log order is not changed. So like have a task that writes to disk and put the log messages that are to be written into a concurrent queue or something like this.
With the current implementation Log messages can be arbitrarily reordered if there really is work piling up, since Task.run does not guarantee execution order.