### PR TITLE
Set .End on old Encounter when creating a new one

### DIFF
--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -292,6 +292,7 @@ namespace LostArkLogger
                     var env = new PKTInitEnv(new BitReader(payload));
                     beforeNewZone?.Invoke();
                     if (currentEncounter.Infos.Count <= 15) Encounters.Remove(currentEncounter);
+                    else currentEncounter.End = DateTime.Now;
 
                     currentEncounter = new Encounter();
                     Encounters.Add(currentEncounter);
@@ -339,7 +340,7 @@ namespace LostArkLogger
                             }
                         }
                     }
-
+                    currentEncounter.End = DateTime.Now;
                     currentEncounter = new Encounter();
                     currentEncounter.Entities = Encounters.Last().Entities; // preserve entities
                     if (WasWipe || Encounters.Last().AfterWipe)


### PR DESCRIPTION
this should fix the buff tracker time percentage calculations