### PR TITLE
Update modifier usage to fit the game

### DIFF
--- a/LostArkLogger/Data/DamageModifierFlags.cs
+++ b/LostArkLogger/Data/DamageModifierFlags.cs
@@ -32,6 +32,7 @@ namespace LostArkLogger
     }
     public enum HitOption : int
     {
+        HIT_OPTION_NONE = -1,
         HIT_OPTION_BACK_ATTACK = 0,
         HIT_OPTION_FRONTAL_ATTACK = 1,
         HIT_OPTION_FLANK_ATTACK = 2,

--- a/LostArkLogger/Data/DamageModifierFlags.cs
+++ b/LostArkLogger/Data/DamageModifierFlags.cs
@@ -29,9 +29,6 @@ namespace LostArkLogger
         HIT_FLAG_DAMAGE_SHARE = 11,
         HIT_FLAG_DODGE_HIT = 12,
         HIT_FLAG_MAX = 13,
-        HIT_OPTION_BACK_ATTACK = 1 << (0 + 4),
-        HIT_OPTION_FRONTAL_ATTACK = 1 << (1 + 4),
-        HIT_OPTION_FLANK_ATTACK = 1 << (2 + 4),
     }
     public enum HitOption : int
     {

--- a/LostArkLogger/Data/DamageModifierFlags.cs
+++ b/LostArkLogger/Data/DamageModifierFlags.cs
@@ -13,7 +13,7 @@ namespace LostArkLogger
         UnkModifier2 = 0x40,
         UnkModifier3 = 0x80
     }
-    [Flags] public enum HitFlag : int
+    public enum HitFlag : int
     {
         HIT_FLAG_NORMAL = 0,
         HIT_FLAG_CRITICAL = 1,

--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -124,7 +124,7 @@ namespace LostArkLogger
             var hitFlag = (HitFlag)(dmgEvent.Modifier & 0xf);
             if (hitFlag == HitFlag.HIT_FLAG_DAMAGE_SHARE && skillId == 0 && skillEffectId == 0)
                 return;
-            var hitOption = (HitOption)((dmgEvent.Modifier & 0x30) >> 4);
+            var hitOption = (HitOption)(((dmgEvent.Modifier >> 4) & 0x7) - 1);
             var skillName = Skill.GetSkillName(skillId, skillEffectId);
             var targetEntity = currentEncounter.Entities.GetOrAdd(dmgEvent.TargetId);
             var destinationName = targetEntity != null ? targetEntity.VisibleName : dmgEvent.TargetId.ToString("X");

--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -121,8 +121,10 @@ namespace LostArkLogger
 
         void ProcessDamageEvent(Entity sourceEntity, UInt32 skillId, UInt32 skillEffectId, SkillDamageEvent dmgEvent)
         {
-            if (((HitFlag)dmgEvent.Modifier == HitFlag.HIT_FLAG_DAMAGE_SHARE) && skillId == 0 && skillEffectId == 0)
+            var hitFlag = (HitFlag)(dmgEvent.Modifier & 0xf);
+            if (hitFlag == HitFlag.HIT_FLAG_DAMAGE_SHARE && skillId == 0 && skillEffectId == 0)
                 return;
+            var hitOption = (HitOption)((dmgEvent.Modifier & 0x3) >> 4);
             var skillName = Skill.GetSkillName(skillId, skillEffectId);
             var targetEntity = currentEncounter.Entities.GetOrAdd(dmgEvent.TargetId);
             var destinationName = targetEntity != null ? targetEntity.VisibleName : dmgEvent.TargetId.ToString("X");
@@ -136,12 +138,9 @@ namespace LostArkLogger
                 SkillEffectId = skillEffectId,
                 SkillName = skillName,
                 Damage = (ulong)dmgEvent.Damage,
-                Crit =
-                    ((HitFlag)dmgEvent.Modifier &
-                     (HitFlag.HIT_FLAG_CRITICAL |
-                      HitFlag.HIT_FLAG_DOT_CRITICAL)) > 0,
-                BackAttack = ((HitFlag)dmgEvent.Modifier & (HitFlag.HIT_OPTION_BACK_ATTACK)) > 0,
-                FrontAttack = ((HitFlag)dmgEvent.Modifier & (HitFlag.HIT_OPTION_FRONTAL_ATTACK)) > 0
+                Crit = hitFlag == HitFlag.HIT_FLAG_CRITICAL || hitFlag == HitFlag.HIT_FLAG_DOT_CRITICAL,
+                BackAttack = hitOption == HitOption.HIT_OPTION_BACK_ATTACK,
+                FrontAttack = hitOption == HitOption.HIT_OPTION_FRONTAL_ATTACK
             };
             onCombatEvent?.Invoke(log);
             currentEncounter.RaidInfos.Add(log);

--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -124,7 +124,7 @@ namespace LostArkLogger
             var hitFlag = (HitFlag)(dmgEvent.Modifier & 0xf);
             if (hitFlag == HitFlag.HIT_FLAG_DAMAGE_SHARE && skillId == 0 && skillEffectId == 0)
                 return;
-            var hitOption = (HitOption)((dmgEvent.Modifier & 0x3) >> 4);
+            var hitOption = (HitOption)((dmgEvent.Modifier & 0x30) >> 4);
             var skillName = Skill.GetSkillName(skillId, skillEffectId);
             var targetEntity = currentEncounter.Entities.GetOrAdd(dmgEvent.TargetId);
             var destinationName = targetEntity != null ? targetEntity.VisibleName : dmgEvent.TargetId.ToString("X");


### PR DESCRIPTION
As we talked about on Discord, HitFlag and HitOptions are Enums and not flags, which makes the old processing wrong.
I've updated it to fit how the game handles it.

Regarding Back Front attack, I don't think the game ever uses HIT_OPTION_FLANK_ATTACK, and if it should be counted as both back and front attack, or somthing different.