### PR TITLE
Add Battle Item logging and display in overlay

### DIFF
--- a/LostArkLogger/Data/BattleItem.cs
+++ b/LostArkLogger/Data/BattleItem.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+
+namespace LostArkLogger
+{
+    public class BattleItem
+    {
+       public static Dictionary<uint, string> Projectiles = new Dictionary<uint, string>()
+       {
+           {33200, "Pheromone Bomb"  },
+           {32000, "Flash Grenade"   },  {32004, "Splendid Flash Grenade"},
+           {32010, "Flame Grenade"   },  {32016, "Splendid Flame Grenade"},
+           {32020, "Frost Grenade"   },  {23025, "Splendid Frost Grenade"},
+           {32030, "Electric Grenade"},  {32035, "Splendid Lightening Grenade"},
+           {32240, "Dark Grenade"    },  {32244, "Splendid Dark Grenade" },
+           {32260, "Corrosive Bomb"  },  {32262, "Splendid Corrosive Bomb"},
+           {32310, "Whirlwind Grenade"}, {32313, "Splendid Whirlwind Greande"},
+           {32320, "Clay Grenade"     }, {32325, "Splendid Clay Grenade"},
+           {32350, "Sleep Bomb" },       {32352, "Splendid Sleep Bomb"},
+           {32360, "Sacred Bomb" },      {32363, "Splendid Sleep Bomb"},
+           {32140, "Destruction Bomb" }, {32142, "Splendid Destruction Bomb"}
+       };
+       public static Dictionary<uint, string> Buffs = new Dictionary<uint, string>()
+       {
+           {32380, "Atropine Potion" },
+           {32100, "Marching Flag" },    {32102, "Splendid Marching Flag"},
+           {32270, "Protective Potion"}, {32271, "Splendid Protective Potion"},
+           {32300, "Sprinter's Robe" },  {32301, "Splendid Sprinter's Robe" },
+           {33500, "Time Stop Potion" },
+           {32402, "Thunder Potion" },   {32403, "Splendid Thunder Potion"}
+       };
+
+        public static bool IsBattleItem(uint id, string type)
+        {
+            if (type == "projectile") return Projectiles.ContainsKey(id);
+            if (type == "buff") return Buffs.ContainsKey(id);
+            else return false;
+        }
+
+        public static string GetBattleItemName(uint id)
+        {
+            if (Projectiles.ContainsKey(id))
+                return Projectiles[id];
+            else 
+                return Buffs[id];
+        }
+    }
+}

--- a/LostArkLogger/Data/Encounter.cs
+++ b/LostArkLogger/Data/Encounter.cs
@@ -89,5 +89,17 @@ namespace LostArkLogger
             return grouped.Select(i => new KeyValuePair<String, Tuple<UInt64, UInt32, UInt32, UInt64>>(i.Key, Tuple.Create((UInt64)i.Sum(sum), (UInt32)i.Count(), (UInt32)i.Count(log => log.Crit), (UInt64)i.Sum(j => (Single)j.TimeAlive)))).ToDictionary(x => x.Key, x => x.Value);
             //return grouped.Select(i => new KeyValuePair<String, UInt64>(i.Key, (UInt64)i.Sum(j => (Single)j.Damage))).ToDictionary(x => x.Key, x => x.Value);
         }
+
+        public Dictionary<String, Tuple<UInt64, UInt32, UInt32, UInt64>> GetBattleItems(Func<LogInfo, float> sum, Entity entity = default(Entity))
+        {
+            var baseSearch = Infos.Where(i => i.SourceEntity.Type == Entity.EntityType.Player).Where(i => i.BattleItem);
+
+            IEnumerable<IGrouping<String, LogInfo>> grouped;
+            if (entity != default(Entity))
+                grouped = baseSearch.Where(i => i.SourceEntity == entity).GroupBy(i => i.SkillName);
+            else
+                grouped = baseSearch.GroupBy(i => i.SourceEntity.VisibleName);
+            return grouped.Select(i => new KeyValuePair<String, Tuple<UInt64, UInt32, UInt32, UInt64>>(i.Key, Tuple.Create((UInt64)i.Sum(sum), (UInt32)i.Count(), (UInt32)i.Count(log => log.Crit), (UInt64)i.Sum(j => (Single)j.TimeAlive)))).ToDictionary(x => x.Key, x => x.Value);
+        }
     }
 }

--- a/LostArkLogger/Data/LogInfo.cs
+++ b/LostArkLogger/Data/LogInfo.cs
@@ -20,6 +20,7 @@ namespace LostArkLogger
         public Boolean Counter { get; set; }
         public Boolean Death { get; set; }
         public TimeSpan Duration { get; set; }
+        public Boolean BattleItem { get; set; }
         public override string ToString()
         {
             return Time.ToString("yy:MM:dd:HH:mm:ss.f") + "," +

--- a/LostArkLogger/GUI/Overlay.cs
+++ b/LostArkLogger/GUI/Overlay.cs
@@ -22,6 +22,7 @@ namespace LostArkLogger
             TimeAlive,
             RaidTimeAlive,
             RaidDamage,
+            BattleItems,
             Max
         }
         enum Scope // need better state, suboverlay type/etc.
@@ -197,6 +198,7 @@ namespace LostArkLogger
                 else if (level == Level.Counterattacks) rows = encounter.Counterattacks.ToDictionary(x => x.Key, x => Tuple.Create(x.Value, 0u, 0u, 0ul));
                 else if (level == Level.Stagger) rows = encounter.Stagger.ToDictionary(x => x.Key, x => Tuple.Create(x.Value, 0u, 0u, 0ul));
                 else if (level == Level.TimeAlive) rows = encounter.TimeAlive.ToDictionary(x => x.Key, x => Tuple.Create(x.Value, 0u, 0u, 0ul));
+                else if (level == Level.BattleItems) rows = encounter.GetBattleItems((i => i.BattleItem ? 1 : 0), SubEntity);
                 else if (level == Level.RaidTimeAlive)
                 {
                     rows = encounter.RaidTimeAlive.ToDictionary(x => x.Key, x => Tuple.Create(x.Value, 0u, 0u, 0ul));

--- a/LostArkLogger/Packets/Steam/NpcStruct.cs
+++ b/LostArkLogger/Packets/Steam/NpcStruct.cs
@@ -6,10 +6,10 @@ namespace LostArkLogger
     {
         public void SteamDecode(BitReader reader)
         {
-            u64_0 = reader.ReadUInt64();
+            NpcId = reader.ReadUInt64();
             b_0 = reader.ReadByte();
             if (b_0 == 1)
-                NpcType = reader.ReadUInt32();
+                u32_2 = reader.ReadUInt32();
             b_11 = reader.ReadByte();
             if (b_11 == 1)
                 b_12 = reader.ReadByte();
@@ -40,7 +40,7 @@ namespace LostArkLogger
             b_6 = reader.ReadByte();
             if (b_6 == 1)
                 u32_0 = reader.ReadUInt32();
-            NpcId = reader.ReadUInt64();
+            u64_0 = reader.ReadUInt64();
             b_7 = reader.ReadByte();
             if (b_7 == 1)
                 u16_0 = reader.ReadUInt16();
@@ -63,7 +63,7 @@ namespace LostArkLogger
             b_17 = reader.ReadByte();
             if (b_17 == 1)
                 u32_1 = reader.ReadUInt32();
-            u32_2 = reader.ReadUInt32();
+            NpcType = reader.ReadUInt32();
             b_18 = reader.ReadByte();
             u16_2 = reader.ReadUInt16();
             statPair = reader.Read<StatPair>();

--- a/LostArkLogger/Packets/Steam/StatusEffectData.cs
+++ b/LostArkLogger/Packets/Steam/StatusEffectData.cs
@@ -6,7 +6,7 @@ namespace LostArkLogger
     {
         public void SteamDecode(BitReader reader)
         {
-            SourceId = reader.ReadSimpleInt();
+            u64_1 = reader.ReadSimpleInt();
             bytearraylist_0 = reader.ReadList<Byte[]>(7);
             hasValue = reader.ReadByte();
             if (hasValue == 1)
@@ -18,8 +18,8 @@ namespace LostArkLogger
                 u64_0 = reader.ReadUInt64();
             u32_0 = reader.ReadUInt32();
             StatusEffectId = reader.ReadUInt32();
-            u64_1 = reader.ReadUInt64();
             InstanceId = reader.ReadUInt64();
+            SourceId = reader.ReadUInt64();
             SkillLevel = reader.ReadByte();
         }
     }

--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -302,7 +302,7 @@ namespace LostArkLogger
                             BattleItem = battleitem
                         };
                         currentEncounter.Infos.Add(log);
-                        Logger.AppendLog(15, projectile.OwnerId.ToString("X"), entity.Name, projectile.SkillId.ToString(), Skill.GetSkillName(projectile.SkillId));
+                        Logger.AppendLog(15, projectile.OwnerId.ToString("X"), entity.Name, projectile.SkillId.ToString(), BattleItem.GetBattleItemName(projectile.SkillId));
                     }
                 }
                 else if (opcode == OpCodes.PKTInitEnv)
@@ -552,7 +552,7 @@ namespace LostArkLogger
                             BattleItem = battleItem
                         };
                         currentEncounter.Infos.Add(log);
-                        Logger.AppendLog(15, statusEffect.statusEffectData.SourceId.ToString("X"), currentEncounter.Entities.GetOrAdd(statusEffect.statusEffectData.SourceId).Name, statusEffect.statusEffectData.StatusEffectId.ToString(), SkillBuff.GetSkillBuffName(statusEffect.statusEffectData.StatusEffectId));
+                        Logger.AppendLog(15, statusEffect.statusEffectData.SourceId.ToString("X"), currentEncounter.Entities.GetOrAdd(statusEffect.statusEffectData.SourceId).Name, statusEffect.statusEffectData.StatusEffectId.ToString(), BattleItem.GetBattleItemName(statusEffect.statusEffectData.StatusEffectId));
                     }
                     statusEffectTracker.Add(statusEffect);
                     var amount = statusEffect.statusEffectData.hasValue == 1 ? BitConverter.ToUInt32(statusEffect.statusEffectData.Value, 0) : 0;

--- a/LostArkLogger/Parser.cs
+++ b/LostArkLogger/Parser.cs
@@ -288,6 +288,22 @@ namespace LostArkLogger
                         EntityId = projectile.ProjectileId,
                         Type = Entity.EntityType.Projectile
                     });
+                    var battleitem = BattleItem.IsBattleItem(projectile.SkillId, "projectile");
+                    if (battleitem)
+                    {
+                        Entity entity = currentEncounter.Entities.GetOrAdd(projectile.OwnerId);
+                        var log = new LogInfo
+                        {
+                            Time = DateTime.Now,
+                            SourceEntity = entity,
+                            DestinationEntity = entity, //projectiles don't have destination, but can't be null causes exception getting encounter name
+                            SkillName = BattleItem.GetBattleItemName(projectile.SkillId),
+                            SkillId = projectile.SkillId,
+                            BattleItem = battleitem
+                        };
+                        currentEncounter.Infos.Add(log);
+                        Logger.AppendLog(15, projectile.OwnerId.ToString("X"), entity.Name, projectile.SkillId.ToString(), Skill.GetSkillName(projectile.SkillId));
+                    }
                 }
                 else if (opcode == OpCodes.PKTInitEnv)
                 {
@@ -523,6 +539,21 @@ namespace LostArkLogger
                 else if (opcode == OpCodes.PKTStatusEffectAddNotify) // shields included
                 {
                     var statusEffect = new PKTStatusEffectAddNotify(new BitReader(payload));
+                    var battleItem = BattleItem.IsBattleItem(statusEffect.statusEffectData.StatusEffectId, "buff");
+                    if (battleItem)
+                    {
+                        var log = new LogInfo
+                        {
+                            Time = DateTime.Now,
+                            SourceEntity = currentEncounter.Entities.GetOrAdd(statusEffect.statusEffectData.SourceId),
+                            DestinationEntity = currentEncounter.Entities.GetOrAdd(statusEffect.ObjectId),
+                            SkillId = statusEffect.statusEffectData.StatusEffectId,
+                            SkillName = BattleItem.GetBattleItemName(statusEffect.statusEffectData.StatusEffectId),
+                            BattleItem = battleItem
+                        };
+                        currentEncounter.Infos.Add(log);
+                        Logger.AppendLog(15, statusEffect.statusEffectData.SourceId.ToString("X"), currentEncounter.Entities.GetOrAdd(statusEffect.statusEffectData.SourceId).Name, statusEffect.statusEffectData.StatusEffectId.ToString(), SkillBuff.GetSkillBuffName(statusEffect.statusEffectData.StatusEffectId));
+                    }
                     statusEffectTracker.Add(statusEffect);
                     var amount = statusEffect.statusEffectData.hasValue == 1 ? BitConverter.ToUInt32(statusEffect.statusEffectData.Value, 0) : 0;
                 }


### PR DESCRIPTION
Quick disclaimer: I am using this project to learn. If I messed something up or there's a better way to do things please let me know.

battle item tracking is done through either the projectile they create or the buff they give the user.
items that do neither (flares, stimulants, luttera's horn) aren't tracked.
Added a new level in overlay for displaying battle items.
I wasn't sure what log line to use, just used 15 but can change to anything